### PR TITLE
Changed the SpatialGaussian to a fully 2D Gaussian

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,16 @@ authors = ["Jeff Eldredge <jdeldre@g.ucla.edu>"]
 version = "0.1.3"
 
 [deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 ForwardDiff = "0.10"
+StaticArrays = "1.5, 1.6"
+UnPack = "1.0"
 julia = "1"
 
 [extras]

--- a/src/SpaceTimeFields.jl
+++ b/src/SpaceTimeFields.jl
@@ -1,9 +1,12 @@
 module SpaceTimeFields
 
+  using UnPack
+
   import Base: +, -, *, show
 
   export EldredgeRamp, ColoniusRamp, Sinusoid, Gaussian, DGaussian, ConstantProfile, d_dt
   export EmptySpatialField, SpatialGaussian
+  export AbstractSpatialField, Abstract1DProfile, SpatialField, SpatialTemporalField
 
 
   include("1dprofiles.jl")

--- a/src/spatialfields.jl
+++ b/src/spatialfields.jl
@@ -1,5 +1,7 @@
 ### Routines for constructing smooth functions that generate field data ###
 
+using LinearAlgebra
+using StaticArrays
 abstract type AbstractSpatialField end
 
 
@@ -23,6 +25,30 @@ julia> g(2,3)
 struct EmptySpatialField <: AbstractSpatialField end
 (g::EmptySpatialField)(a...) = Float64(0)
 
+## Basic spatial field ##
+"""
+    SpatialField(f::Function)
+
+Creates a lazy instance of a spatial field from a function `f`, which
+must have the signature `f(x,y)`.
+"""
+struct SpatialField{FT<:Function} <: AbstractSpatialField
+  f :: FT
+end
+(field::SpatialField)(x,y) = field.f(x,y)
+(field::SpatialField)(x,y,t) = field.f(x,y) # ignore the time argument
+
+"""
+    SpatialTemporalField(f::Function)
+
+Creates a lazy instance of a spatial-temporal field from a function `f`, which
+must have the signature `f(x,y,t)`.
+"""
+struct SpatialTemporalField{FT<:Function} <: AbstractSpatialField
+  f :: FT
+end
+(field::SpatialTemporalField)(x,y,t) = field.f(x,y,t)
+
 
 ## Spatial Gaussian field ##
 
@@ -37,23 +63,77 @@ derivative of a Gaussian in that direction (`x` or `y`, respectively).
 `SpatialGaussian(σx,σy,x0,y0,A,u,v[,derivdir=0])` generates a Gaussian
 that convects at velocity `(u,v)`. It can be evaluated with an additional
 argument for time.
+""" SpatialGaussian(::Real,::Real,::Real,::Real,::Real)
+
 """
-struct SpatialGaussian{CT,GX,GY} <: AbstractSpatialField
-  gx :: GX
-  gy :: GY
+    SpatialGaussian(Σ::Matrix,x0::Vector,A::Real[,derivdir=0])
+
+Set up a spatial field in the form of a Gaussian centered at `x0[1],x0[2]` with
+covariance matrix `Σ` and amplitude `A`. If the
+optional parameter `deriv` is set to 1 or 2, then it returns the first
+derivative of a Gaussian in that direction (`x` or `y`, respectively).
+""" SpatialGaussian(::AbstractMatrix,::Vector,::Real)
+
+"""
+    SpatialGaussian(σ::Vector,x0::Real,y0::Real,α::Real,A::Real[,derivdir=0])
+
+Set up a spatial field in the form of a Gaussian centered at `x0,y0` with
+variances `σ[1],σ[2]` along the orthoogonal eigendirections, which are rotated by `α`
+with respect to the coordinate system; and amplitude `A`. If the
+optional parameter `deriv` is set to 1 or 2, then it returns the first
+derivative of a Gaussian in that direction (`x` or `y`, respectively).
+""" SpatialGaussian(::Vector,::Real,::Real,::Real,::Real)
+
+
+struct SpatialGaussian{CT,D} <: AbstractSpatialField
+  Σ :: SMatrix{2,2,Float64,4}
+  Σinv :: SMatrix{2,2,Float64,4}
+  x0 :: SVector{2,Float64}
   A :: Float64
-  u :: Float64
-  v :: Float64
-  SpatialGaussian(gx::Abstract1DProfile,gy::Abstract1DProfile,A,u,v) = new{true,typeof(gx),typeof(gy)}(gx,gy,A,u,v)
-  SpatialGaussian(gx::Abstract1DProfile,gy::Abstract1DProfile,A) = new{false,typeof(gx),typeof(gy)}(gx,gy,A,0.0,0.0)
+  fact :: Float64
+  u :: SVector{2,Float64}
+  SpatialGaussian(Σ::SMatrix,x0::SVector,A::Real;derivdir=0) = new{false,derivdir}(Σ,inv(Σ),x0,A,A/(2π*sqrt(det(Σ))),SVector{2}(0.0,0.0))
+  SpatialGaussian(Σ::SMatrix,x0::SVector,A::Real,u::SVector;derivdir=0) = new{true,derivdir}(Σ,inv(Σ),x0,A,A/(2π*sqrt(det(Σ))),u)
+  #SpatialGaussian(gx::Abstract1DProfile,gy::Abstract1DProfile,A,u,v) = new{true,typeof(gx),typeof(gy)}(gx,gy,A,u,v)
+  #SpatialGaussian(gx::Abstract1DProfile,gy::Abstract1DProfile,A) = new{false,typeof(gx),typeof(gy)}(gx,gy,A,0.0,0.0)
 end
 
+
+function SpatialGaussian(σ2::Vector,x0::Real,y0::Real,α::Real,A::Real;kwargs...)
+    R = _rotation_matrix(α)
+    Σ = R*SMatrix{2,2}(Diagonal(σ2))*R'
+    x0v = SVector{2}(x0,y0)
+    SpatialGaussian(Σ,x0v,A;kwargs...)
+end
+
+function SpatialGaussian(σ2::Vector,x0::Real,y0::Real,α::Real,A::Real,u::Real,v::Real;kwargs...)
+    R = _rotation_matrix(α)
+    Σ = R*SMatrix{2,2}(Diagonal(σ2))*R'
+    x0v = SVector{2}(x0,y0)
+    uv = SVector{2}(u,v)
+    SpatialGaussian(Σ,x0v,A,uv;kwargs...)
+end
+
+SpatialGaussian(Σ::AbstractMatrix,x0::Vector,a...;kwargs...) = SpatialGaussian(SMatrix{2,2}(Σ),SVector{2}(x0),a...;kwargs...)
+
+SpatialGaussian(σx::Real,σy::Real,x0::Real,y0::Real,a...;kwargs...) = SpatialGaussian([σx^2,σy^2],x0,y0,0.0,a...;kwargs...)
+
+
+
+function _rotation_matrix(θ::Real)
+    cth, sth = cos(θ), sin(θ)
+    R = @SMatrix[cth -sth; sth cth]
+    return R
+end
+
+#=
 SpatialGaussian(σx::Real,σy::Real,x0::Real,y0::Real,A::Real;deriv::Int=0) =
                 _spatialdgaussian(σx,σy,x0,y0,A,Val(deriv))
 SpatialGaussian(σx::Real,σy::Real,x0::Real,y0::Real,A::Real,u::Real,v::Real;deriv::Int=0) =
                 _spatialdgaussian(σx,σy,x0,y0,A,u,v,Val(deriv))
+=#
 
-
+#=
 _spatialdgaussian(σx,σy,x0,y0,A,::Val{0}) = SpatialGaussian(Gaussian(σx,A) >> x0,
                                                             Gaussian(σy,1) >> y0,A)
 _spatialdgaussian(σx,σy,x0,y0,A,::Val{1}) = SpatialGaussian(DGaussian(σx,A) >> x0,
@@ -70,13 +150,41 @@ _spatialdgaussian(σx,σy,x0,y0,A,u,v,::Val{2}) = SpatialGaussian(Gaussian(σx,A
 
 
 SpatialGaussian(σ,x0,y0,A;deriv::Int=0) = SpatialGaussian(σ,σ,x0,y0,A,deriv=deriv)
+=#
 
+function (g::SpatialGaussian{C,0})(x,y) where {C}
+    @unpack x0, Σinv, fact = g
+    xv = SVector{2}(x,y)
+    return _spatialgaussian(fact,xv-x0,Σinv)
+end
 
+function (g::SpatialGaussian{C,N})(x,y) where {C,N}
+    @unpack x0, Σinv, fact = g
+    xv = SVector{2}(x,y)
+    dx = xv-x0
+    dfact = -Σinv*dx
+    return _spatialgaussian(fact,dx,Σinv)*dfact[N]
+end
+
+(g::SpatialGaussian{false,N})(x,y,t) where {N} = g(x,y)
+(g::SpatialGaussian{true,N})(x,y,t) where {N} = g(x-g.u[1]*t,y-g.u[2]*t)
+
+function (g::SpatialGaussian{C,N})(x,y) where {C,N}
+    @unpack x0, Σinv, fact = g
+    xv = SVector{2}(x,y)
+    dx = xv-x0
+    dfact = -Σinv*dx
+    return _spatialgaussian(fact,dx,Σinv)*dfact[N]
+end
+
+_spatialgaussian(fact::Real,x::SVector,Σinv::SMatrix) = fact*exp(-0.5*x'*Σinv*x)
+
+#=
 (g::SpatialGaussian{GX,GY})(x,y) where {GX,GY} = g.gx(x)*g.gy(y)
 # ignore the time argument if it is called with this...
 (g::SpatialGaussian{false,GX,GY})(x,y,t) where {GX,GY} = g(x,y)
 (g::SpatialGaussian{true,GX,GY})(x,y,t) where {GX,GY} = g.gx(x-g.u*t)*g.gy(y-g.v*t)
-
+=#
 
 ## Scaling spatial fields
 

--- a/src/spatialfields.jl
+++ b/src/spatialfields.jl
@@ -75,10 +75,10 @@ derivative of a Gaussian in that direction (`x` or `y`, respectively).
 """ SpatialGaussian(::AbstractMatrix,::Vector,::Real)
 
 """
-    SpatialGaussian(σ::Vector,x0::Real,y0::Real,α::Real,A::Real[,derivdir=0])
+    SpatialGaussian(σ2::Vector,x0::Real,y0::Real,α::Real,A::Real[,derivdir=0])
 
 Set up a spatial field in the form of a Gaussian centered at `x0,y0` with
-variances `σ[1],σ[2]` along the orthoogonal eigendirections, which are rotated by `α`
+variances `σ2[1],σ2[2]` along the orthogonal eigendirections, which are rotated by `α`
 with respect to the coordinate system; and amplitude `A`. If the
 optional parameter `deriv` is set to 1 or 2, then it returns the first
 derivative of a Gaussian in that direction (`x` or `y`, respectively).
@@ -169,13 +169,6 @@ end
 (g::SpatialGaussian{false,N})(x,y,t) where {N} = g(x,y)
 (g::SpatialGaussian{true,N})(x,y,t) where {N} = g(x-g.u[1]*t,y-g.u[2]*t)
 
-function (g::SpatialGaussian{C,N})(x,y) where {C,N}
-    @unpack x0, Σinv, fact = g
-    xv = SVector{2}(x,y)
-    dx = xv-x0
-    dfact = -Σinv*dx
-    return _spatialgaussian(fact,dx,Σinv)*dfact[N]
-end
 
 _spatialgaussian(fact::Real,x::SVector,Σinv::SMatrix) = fact*exp(-0.5*x'*Σinv*x)
 

--- a/test/spatialfields.jl
+++ b/test/spatialfields.jl
@@ -25,13 +25,13 @@ g = EmptySpatialField()
 @test g(rand(2)...) == 0.0
 
 g = SpatialGaussian(σ,σ,0.0,0.5,1)
-@test g(0,0.5+σ) ≈ g(σ,0.5) ≈ g(-σ,0.5) ≈ g(0,0.5-σ) ≈ exp(-1)/(π*σ^2)
+@test g(0,0.5+σ) ≈ g(σ,0.5) ≈ g(-σ,0.5) ≈ g(0,0.5-σ) ≈ A*exp(-1/2)/(2π*σ^2)
 
 u = 1
 v = 0
 gc = SpatialGaussian(σ,σ,0.0,0.5,1,u,v)
 t = 1
-@test gc(u*t,0.5+σ+v*t,t) ≈ gc(σ+u*t,0.5+v*t,t) ≈ gc(-σ+u*t,0.5+v*t,t) ≈ gc(0+u*t,0.5-σ+v*t,t) ≈ exp(-1)/(π*σ^2)
+@test gc(u*t,0.5+σ+v*t,t) ≈ gc(σ+u*t,0.5+v*t,t) ≈ gc(-σ+u*t,0.5+v*t,t) ≈ gc(0+u*t,0.5-σ+v*t,t) ≈ A*exp(-1/2)/(2π*σ^2)
 
 
 
@@ -39,10 +39,10 @@ g = EmptySpatialField()
 for x in [-0.5,0,0.5], y in [-0.5,0,0.5]
   g += SpatialGaussian(0.2,0.5,x,y,1)
 end
-@test g(0.5,0) ≈ 5.5357580598289235
+@test g(0.5,0) ≈ 3.6769641226297485
 
 g2 = -g
-@test g2(0.5,0) ≈ -5.5357580598289235
+@test g2(0.5,0) ≈ -3.6769641226297485
 
 
 
@@ -56,10 +56,10 @@ end
   x0 = 0
   y0 = 0
   A = 1
-  dgaussx = SpatialGaussian(σx,σy,x0,y0,A,deriv=1)
-  dgaussy = SpatialGaussian(σx,σy,x0,y0,A,deriv=2)
+  dgaussx = SpatialGaussian(σx,σy,x0,y0,A,derivdir=1)
+  dgaussy = SpatialGaussian(σx,σy,x0,y0,A,derivdir=2)
   x = 0.1
   y = 0.2
-  @test dgaussx(0.1,0.2) == dgaussy(0.2,0.1) ≈ -2*A*x/π/σx^3/σy*exp(-x^2/σx^2)*exp(-y^2/σy^2)
+  @test dgaussx(0.1,0.2) == dgaussy(0.2,0.1) ≈ -A*x/(2π*σx^3*σy)*exp(-0.5*x^2/σx^2)*exp(-0.5*y^2/σy^2)
 
 end


### PR DESCRIPTION
The `SpatialGaussian` function now allows one to create a Gaussian field with more generality, including at an angle. The main constructor is

`SpatialGaussian(σ2::Vector,x0::Real,y0::Real,α::Real,A::Real[,derivdir=0])`

which will create a Gaussian

$$\frac{A}{2\pi\sqrt{\det\Sigma}} \exp\left(-\frac{1}{2} (x-\mu)^T \Sigma^{-1} (x-\mu)\right)$$

with $\mu = (x0,y0)$ and covariance matrix

$$\Sigma =  R(\alpha)\begin{pmatrix}\sigma_1^2 & 0 \\\\ 0 & \sigma_2^2\end{pmatrix}R'(\alpha)$$

where $R(\alpha)$ is the rotation matrix for angle α